### PR TITLE
Add chcholor action 

### DIFF
--- a/src/LSystem.js
+++ b/src/LSystem.js
@@ -84,6 +84,9 @@ function compileActions(systemSettings, lSystem) {
     '-': {name: 'rotate', args: [-defaultRotationAngle]},
     '[': {name: 'push', args: []},
     ']': {name: 'pop', args: []},
+    'c': {name: 'chcolor', args: []},
+    'd': {name: 'chcolor', args: []},
+    'e': {name: 'chcolor', args: []},
     ...systemSettings.actions
   }
 
@@ -120,6 +123,13 @@ function turtleCanDo(command, lSystem) {
     }
   }
 
+  if (command.name === 'chcolor') {
+    let color = command.args[0];
+    return function() {
+      lSystem.turtle.chcolor(color)
+    }
+  }
+
   if (command.name === 'push') return function() {lSystem.turtle.push()}
   if (command.name === 'pop') return function() {lSystem.turtle.pop()}
   if (command.name === 'move') {
@@ -133,7 +143,7 @@ function getLength(value, name) {
   let length = 10;
   if (value !== undefined) {
     length = value;
-    if (!Number.isFinite(length)) throw new Error(name  +'(l) expects `l` to be a float number. Got: ' + value);
+     if (!Number.isFinite(length)) throw new Error(name  +'(l) expects `l` to be a float number. Got: ' + value);
   }
   return length;
 }

--- a/src/Turtle.js
+++ b/src/Turtle.js
@@ -45,16 +45,12 @@ export default class Turtle {
     p[0] = x; p[1] = y; p[2] = z;
   }
 
-  draw(distance,color) {
+  draw(distance) {
     let p = this.position;
     let n = this.direction;
     let x = p[0] + distance * n[0];
     let y = p[1] + distance * n[1];
     let z = p[2] + distance * n[2];
-    //console.log(distance);
-    //console.log(color);
-    //console.log(this.color);
-    if (color) this.color = color;
     this.lines.add({
       from: p, 
       to: [x, y, z],

--- a/src/Turtle.js
+++ b/src/Turtle.js
@@ -1,4 +1,5 @@
 import LineCollection from './LineCollection';
+import tinycolor from 'tinycolor2';
 
 export default class Turtle {
   constructor(scene, options = {}) {
@@ -44,12 +45,16 @@ export default class Turtle {
     p[0] = x; p[1] = y; p[2] = z;
   }
 
-  draw(distance) {
+  draw(distance,color) {
     let p = this.position;
     let n = this.direction;
     let x = p[0] + distance * n[0];
     let y = p[1] + distance * n[1];
     let z = p[2] + distance * n[2];
+    //console.log(distance);
+    //console.log(color);
+    //console.log(this.color);
+    if (color) this.color = color;
     this.lines.add({
       from: p, 
       to: [x, y, z],
@@ -58,6 +63,15 @@ export default class Turtle {
 
     p[0] = x; p[1] = y; p[2] = z;
     this.scene.renderFrame();
+  }
+
+  chcolor(hue) {
+    let list = Object.values(tinycolor.names); 
+    let color = "#";
+    color+= list[hue];
+    let rgba = tinycolor(color).toRgb();
+    color = (rgba.r << 24) | (rgba.g << 16) | (rgba.b << 8) | (rgba.a * 255 | 0)
+    this.color = color;
   }
 
   rotateZ(angleInDegrees) {


### PR DESCRIPTION
This is a compromise, using the tinycolors.names lookup table. Values to array, select index. Not ideal but any other approach currently has an impact on the interpreter. Limits on input (numerical, no hex) probably should be dealt with carefully?

It works for me, and I'm thinking of a simple utility color selector without it getting to fussy.